### PR TITLE
remove travis email notification, slack is enough

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,5 @@ install:
     - pip install tox
 script: tox
 notifications:
-    email:
-        - tech+travis@ona.io
     slack:
         - onaio:snkNXgprD498qQv4DgRREKJF


### PR DESCRIPTION
We've removed (or are in the process of removing) this for all other projects