### PR TITLE
Shapefile error messages

### DIFF
--- a/tasking/__init__.py
+++ b/tasking/__init__.py
@@ -4,5 +4,5 @@ Main init file for tasking app
 """
 from __future__ import unicode_literals
 
-VERSION = (0, 1, 8)
+VERSION = (0, 1, 9)
 __version__ = '.'.join(str(v) for v in VERSION)

--- a/tasking/serializers/location.py
+++ b/tasking/serializers/location.py
@@ -51,6 +51,7 @@ class ShapeFileField(GeometryField):
             # Call get_shapefile method to get the .shp files name
             try:
                 shpfile = get_shapefile(zip_file)
+            # pylint: disable=no-member
             except Exception as e:
                 raise serializers.ValidationError(e.message)
 

--- a/tasking/serializers/location.py
+++ b/tasking/serializers/location.py
@@ -51,9 +51,9 @@ class ShapeFileField(GeometryField):
             # Call get_shapefile method to get the .shp files name
             try:
                 shpfile = get_shapefile(zip_file)
-            # pylint: disable=no-member
-            except Exception as e:
-                raise serializers.ValidationError(e.message)
+            except Exception as exception:
+                # pylint: disable=no-member
+                raise serializers.ValidationError(exception.message)
 
             # Setup a Temporary Directory to store Shapefiles
             with TemporaryDirectory() as temp_dir:

--- a/tasking/serializers/location.py
+++ b/tasking/serializers/location.py
@@ -19,6 +19,8 @@ from rest_framework_gis.serializers import GeometryField
 
 from tasking.common_tags import (GEODETAILS_ONLY, GEOPOINT_MISSING,
                                  RADIUS_MISSING)
+from tasking.exceptions import (UnnecessaryFiles, MissingFiles,
+                                ShapeFileNotFound)
 from tasking.models import Location
 from tasking.utils import get_shapefile
 
@@ -51,9 +53,9 @@ class ShapeFileField(GeometryField):
             # Call get_shapefile method to get the .shp files name
             try:
                 shpfile = get_shapefile(zip_file)
-            except Exception as exception:
+            except (ShapeFileNotFound, MissingFiles, UnnecessaryFiles) as exp:
                 # pylint: disable=no-member
-                raise serializers.ValidationError(exception.message)
+                raise serializers.ValidationError(exp.message)
 
             # Setup a Temporary Directory to store Shapefiles
             with TemporaryDirectory() as temp_dir:

--- a/tasking/serializers/location.py
+++ b/tasking/serializers/location.py
@@ -47,8 +47,12 @@ class ShapeFileField(GeometryField):
                 zip_file = zipfile.ZipFile(value.temporary_file_path())
             except AttributeError:
                 zip_file = zipfile.ZipFile(value)
+
             # Call get_shapefile method to get the .shp files name
-            shpfile = get_shapefile(zip_file)
+            try:
+                shpfile = get_shapefile(zip_file)
+            except Exception as e:
+                raise serializers.ValidationError(e.message)
 
             # Setup a Temporary Directory to store Shapefiles
             with TemporaryDirectory() as temp_dir:

--- a/tests/serializers/test_location.py
+++ b/tests/serializers/test_location.py
@@ -349,7 +349,7 @@ class TestLocationSerializer(TestCase):
 
     def test_bad_shapefile_data(self):
         """
-        Test upload of a bad shapefile returns an error message
+        Test upload of a bad shapefile returns relevant error message
         - missing files
         - shapefile not found
         - unnecessary files


### PR DESCRIPTION
Uploading a bad shapefile over the api results in a Internal Server Error (500).
It's not good for the client side
This handles the error messages and returns them in the response as an invalid shapefile.
This will fix https://github.com/onaio/kaznet-web/issues/260