### PR TITLE
Support Django version 2.2 and 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 matrix:
     include:
@@ -19,7 +19,11 @@ addons:
     postgresql: "9.6"
     apt:
         packages:
-            - postgresql-9.6-postgis-2.3
+            - postgresql-9.6-postgis-2.4
+            - gdal-bin
+            - libgdal-dev
+        sources:
+            - sourceline: 'ppa:ubuntugis/ubuntugis-unstable'
 before_script:
     - psql -c 'CREATE DATABASE ona_tasking;' -U postgres
     - psql -c 'CREATE EXTENSION postgis;' -U postgres -d ona_tasking

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,15 @@ language: python
 matrix:
     include:
         - python: 3.6
-          env: TOXENV=py36
+          env: TOXENV=py36-django22
+        - python: 3.6
+          env: TOXENV=py36-django30
         - python: 3.6
           env: TOXENV=flake8
         - python: 3.6
           env: TOXENV=pylint
+        - python: 3.6
+          env: TOXENV=black
 services:
     - postgresql
 addons:

--- a/Pipfile
+++ b/Pipfile
@@ -23,3 +23,4 @@ black = "==19.10b0"
 
 [packages]
 e1839a8 = {editable = true,path = "."}
+ona-tasking = {editable = true,path = "."}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4423f07b1f255952b80504c367e829655c5876f50109ce8e1d1bd21dcb29f0fc"
+            "sha256": "dcd2e40970dc543ff61b6f18c88584026fd7ee8d9a40d3aef7ba2f1e289ef201"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,12 +14,19 @@
         ]
     },
     "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:7e06d934a7718bf3975acbf87780ba678957b87c7adc056f13b6215d610695a0",
+                "sha256:ea448f92fc35a0ef4b1508f53a04c4670255a3f33d22a81c8fc9c872036adbe5"
+            ],
+            "version": "==3.2.3"
+        },
         "django": {
             "hashes": [
-                "sha256:665457d4146bbd34ae9d2970fa3b37082d7b225b0671bfd24c337458f229db78",
-                "sha256:bde46d4dbc410678e89bc95ea5d312dd6eb4c37d0fa0e19c9415cad94addf22f"
+                "sha256:4f2c913303be4f874015993420bf0bd8fd2097a9c88e6b49c6a92f9bdd3fb13a",
+                "sha256:8c3575f81e11390893860d97e1e0154c47512f180ea55bd84ce8fa69ba8051ca"
             ],
-            "version": "==2.0.13"
+            "version": "==3.0.2"
         },
         "django-countries": {
             "hashes": [
@@ -73,6 +80,10 @@
             ],
             "version": "==3.1.1"
         },
+        "ona-tasking": {
+            "editable": true,
+            "path": "."
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
@@ -93,6 +104,13 @@
                 "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
             "version": "==1.14.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
+                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
+            ],
+            "version": "==0.3.0"
         }
     },
     "develop": {
@@ -141,10 +159,10 @@
         },
         "autopep8": {
             "hashes": [
-                "sha256:4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"
+                "sha256:0f592a0447acea0c2b0a9602be1e4e3d86db52badd2e3c84f0193bfd89fd3a43"
             ],
             "index": "pypi",
-            "version": "==1.4.4"
+            "version": "==1.5"
         },
         "backcall": {
             "hashes": [
@@ -221,10 +239,10 @@
         },
         "django": {
             "hashes": [
-                "sha256:665457d4146bbd34ae9d2970fa3b37082d7b225b0671bfd24c337458f229db78",
-                "sha256:bde46d4dbc410678e89bc95ea5d312dd6eb4c37d0fa0e19c9415cad94addf22f"
+                "sha256:4f2c913303be4f874015993420bf0bd8fd2097a9c88e6b49c6a92f9bdd3fb13a",
+                "sha256:8c3575f81e11390893860d97e1e0154c47512f180ea55bd84ce8fa69ba8051ca"
             ],
-            "version": "==2.0.13"
+            "version": "==3.0.2"
         },
         "entrypoints": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url="https://github.com/onaio/tasking",
     packages=find_packages(exclude=["docs", "tests"]),
     install_requires=[
-        "Django >= 1.11.19, < 2.1",
+        "Django >= 2.2",
         "python-dateutil",
         "markdown",  # adds markdown support for browsable REST API
         "django-filter",  # for filtering in the API
@@ -25,6 +25,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.2",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Framework :: Django",
         "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.0",
     ],
 )

--- a/tests/serializers/test_segment_rules.py
+++ b/tests/serializers/test_segment_rules.py
@@ -76,6 +76,7 @@ class TestSegmentRuleSerializer(TestBase):
             name="Rule Zero",
             description="Some description",
             target_content_type=self.task_type.id,
+            active=False,
             target_field="invalid_field",
             target_field_value=6,
             target_app_label="tasking",
@@ -85,5 +86,5 @@ class TestSegmentRuleSerializer(TestBase):
         self.assertFalse(instance.is_valid())
         self.assertEqual(
             "Task has no field named 'invalid_field'",
-            str(instance.errors["target_field"][0]),
+            instance.errors["target_field"][0],
         )

--- a/tests/viewsets/test_locations.py
+++ b/tests/viewsets/test_locations.py
@@ -4,7 +4,6 @@ Tests Location viewsets.
 import os
 
 from django.test import override_settings
-from django.utils import six
 
 import pytz
 from model_mommy import mommy
@@ -117,9 +116,7 @@ class TestLocationViewSet(TestBase):
                 response = view(request=request)
                 self.assertEqual(response.status_code, 400)
                 self.assertIn("shapefile", response.data.keys())
-                self.assertEqual(
-                    INVALID_SHAPEFILE, six.text_type(response.data["shapefile"][0])
-                )
+                self.assertEqual(INVALID_SHAPEFILE, response.data["shapefile"][0])
 
             # should work
             with self.settings(TASKING_SHAPEFILE_ALLOW_NESTED_MULTIPOLYGONS=True):
@@ -151,9 +148,7 @@ class TestLocationViewSet(TestBase):
                 response = view(request=request)
                 self.assertEqual(response.status_code, 400)
                 self.assertIn("shapefile", response.data.keys())
-                self.assertEqual(
-                    INVALID_SHAPEFILE, six.text_type(response.data["shapefile"][0])
-                )
+                self.assertEqual(INVALID_SHAPEFILE, response.data["shapefile"][0])
 
             # should work
             with self.settings(TASKING_SHAPEFILE_IGNORE_INVALID_TYPES=True):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36
+    py36-django{22,30}
     flake8
     pylint
     black
@@ -22,7 +22,7 @@ commands =
     pipenv sync --dev
     pylint --rcfile={toxinidir}/.pylintrc {toxinidir}/tasking
 
-[testenv: black]
+[testenv:black]
 deps =
     black
     pipenv
@@ -38,6 +38,8 @@ deps =
 basepython = python3.6
 commands =
     pipenv sync --dev
+    django22: pip install Django>=2.2,<2.3
+    django30: pip install Django>=3.0,<3.1
     coverage erase
     coverage run --include="tasking/**.*" --omit="tests/**.*,tasking/migrations/**.*" manage.py test {toxinidir}/tests -v 2
     coverage report


### PR DESCRIPTION
### Changes / Features implemented

- Support Django version 2.2 and 3.0
- Drop support of any version before Django 2.2
- Stop usage of `django.utils.six`. _No longer available from Django 3.0_
- Bump travis dist to xenial
- Test python 3.6 against versions of django

### Steps taken to verify this change does what is intended

- Tested locally
- Tested on travis

### Side effects of implementing this change

Closes #149 
Closes #147 