### PR TITLE
Test the package against python 3.7 and 3.8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ matrix:
           env: TOXENV=py36-django22
         - python: 3.6
           env: TOXENV=py36-django30
+        - python: 3.7
+          env: TOXENV=py37-django22
+        - python: 3.7
+          env: TOXENV=py37-django30
+        - python: 3.8
+          env: TOXENV=py38-django22
+        - python: 3.8
+          env: TOXENV=py38-django30
         - python: 3.6
           env: TOXENV=flake8
         - python: 3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ default_section = THIRDPARTY
 known_first_party = tasking
 known_django = django
 sections = STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36-django{22,30}
+    py{36,37,38}-django{22,30}
     flake8
     pylint
     black
@@ -35,7 +35,10 @@ commands =
 deps =
     pipenv
     coverage
-basepython = python3.6
+basepython =
+    py36: python3.6
+    py37: python3.7
+    py38: python3.8
 commands =
     pipenv sync --dev
     django22: pip install Django>=2.2,<2.3


### PR DESCRIPTION
### Changes / Features implemented

- Update travis configurations
- Test the package against python 3.7 and 3.8
- Delete `.flake8` in favor of `setup.cfg`. It's a more central location for configurations.

### Steps taken to verify this change does what is intended

- Tested locally and on travis

### Side effects of implementing this change

- N/A

Closes #153 
Closes #155 
